### PR TITLE
Cron gestion update and refresh dot bug fix

### DIFF
--- a/core/ajax/mitsubishimelcloud.ajax.php
+++ b/core/ajax/mitsubishimelcloud.ajax.php
@@ -37,7 +37,7 @@ try {
         break;
       
       case 'SynchronizeMELCloud':
-        mitsubishimelcloud::SynchronizeMELCloud();
+        mitsubishimelcloud::SynchronizeMELCloud('button');
         ajax::success();
         break;
     }

--- a/core/class/mitsubishimelcloud.class.php
+++ b/core/class/mitsubishimelcloud.class.php
@@ -47,11 +47,11 @@ class mitsubishimelcloud extends eqLogic {
   /** Collect heat pump data from MELCloud app */
   public static function SynchronizeMELCloud($action = 'cron') {
     $Token = config::byKey('Token', __CLASS__);
-    log::add(__CLASS__, 'info', __('<--- Start MELCloud synchronization launched by : '.$action, __FILE__));
+    log::add(__CLASS__, 'info', __('<--- Start of heat pump synchronization launched by : '.$action, __FILE__));
 
     if($action == 'cron' AND empty($Token)) {
       // When function launched by cron, do not launch the function if no token available
-      log::add(__CLASS__, 'debug', __('No MELCloud synchronization as no Token saved', __FILE__));
+      log::add(__CLASS__, 'debug', 'No cron for heat pump synchronization as no Token saved');
     } else {
       if($Token == '' || substr($Token, 0, 11) == 'Login ERROR') {
         message::add(__CLASS__, __('Merci de récupérer le token MELCloud avant de créer des équipements.', __FILE__));
@@ -97,7 +97,7 @@ class mitsubishimelcloud extends eqLogic {
         }
       }
     }
-    log::add(__CLASS__, 'info', __('<--- End MELCloud synchronization launched by : '.$action, __FILE__));
+    log::add(__CLASS__, 'info', __('<--- End of heat pump synchronization launched by : '.$action, __FILE__));
   }
 
   /** Collect split data from MELCloud app */
@@ -107,7 +107,7 @@ class mitsubishimelcloud extends eqLogic {
 
     if($action == 'cron' AND empty($Token)) {
       // When function launched by cron, do not launch the function if no token available
-      log::add(__CLASS__, 'debug', __('No split synchronization as no Token saved', __FILE__));
+      log::add(__CLASS__, 'debug', 'No cron for split synchronization as no Token saved');
     } else {
       if($Token == '' || substr($Token, 0, 11) == 'Login ERROR') {
         message::add(__CLASS__, __('Merci de récupérer le token MELCloud avant de créer des équipements.', __FILE__));

--- a/core/class/mitsubishimelcloud.class.php
+++ b/core/class/mitsubishimelcloud.class.php
@@ -296,7 +296,8 @@ class mitsubishimelcloud extends eqLogic {
   /** Method called after saving your Jeedom equipment */
   public function postSave() {
     if($this->getConfiguration('deviceid') == ''){
-      self::SynchronizeSplit('PostSave');
+      // If not yet saved, collect first heat pump information
+      self::SynchronizeMELCloud('PostSave');
       if($this->getConfiguration('deviceid') == '') return;
     }
 
@@ -591,6 +592,11 @@ class mitsubishimelcloud extends eqLogic {
         log::add(__CLASS__, 'error', __('Pas de type de PAC trouvé', __FILE__));
         return;
       }
+    }
+
+    if($this->getConfiguration('deviceid') != ''){
+      // If correctly created, collect split information
+      self::SynchronizeSplit('PostSave');
     }
   }
 

--- a/core/class/mitsubishimelcloud.class.php
+++ b/core/class/mitsubishimelcloud.class.php
@@ -103,9 +103,9 @@ class mitsubishimelcloud extends eqLogic {
   /** Collect split data from MELCloud app */
   public static function SynchronizeSplit($action = 'cron') {
     $Token = config::byKey('Token', __CLASS__);
-    log::add(__CLASS__, 'debug', 'Split synchronization launched by : '.$action);
+    log::add(__CLASS__, 'info', '<--- Start Splits synchronization launched by : '.$action);
 
-    if($action == '' AND empty($Token)) {
+    if($action == 'cron' AND empty($Token)) {
       // When function launched by cron, do not launch the function if no token available
       log::add(__CLASS__, 'debug', __('No split synchronization as no Token saved', __FILE__));
     } else {
@@ -137,6 +137,7 @@ class mitsubishimelcloud extends eqLogic {
         }
       }
     }
+    log::add(__CLASS__, 'info', '<--- End Splits synchronization launched by : '.$action);
   }
 
   /** Collect equipment information from Mitsubishi servers for the equipment */

--- a/core/template/dashboard/mitsubishimelcloud.html
+++ b/core/template/dashboard/mitsubishimelcloud.html
@@ -143,9 +143,9 @@
     
   <script>
     /** function to add up to 5 dots on refresh button to display that eh communication is in process */
-    function AddingDots() {
+    function AddingDots(IdRefresh) {
       for (let i = 0; i < 5; i++) {
-        setTimeout(function(){$('.eqLogic[data-eqLogic_uid=#uid#] .refresh').append('.')}, 500 * i);
+        setTimeout(function(){$('.eqLogic[data-eqLogic_uid='+IdRefresh+'] .refresh').append('.')}, 500 * i);
       }
     }
 
@@ -153,18 +153,18 @@
     // Send selected power status to Melcloud
     $(".eqLogic[data-eqLogic_uid=#uid#] .SwitchOn").click(function(){
       jeedom.cmd.execute({id: '#On_Cmd#'});
-      AddingDots();
+      AddingDots('#uid#');
     });
     $(".eqLogic[data-eqLogic_uid=#uid#] .SwitchOff").click(function(){
       jeedom.cmd.execute({id: '#Off_Cmd#'});
-      AddingDots();
+      AddingDots('#uid#');
     });
 
 
     /* Refresh button */
     $('.eqLogic[data-eqLogic_uid=#uid#] .refresh').on('click', function () {
       jeedom.cmd.execute({id: '#refresh#'});
-      AddingDots();
+      AddingDots('#uid#');
     });
 
     /* Mode */
@@ -175,7 +175,7 @@
     // Send selected mode to Melcloud
     $(".eqLogic[data-eqLogic_uid=#uid#] .ModeSelection label").click(function(){
       jeedom.cmd.execute({id: '#OperationMode_Cmd#', value: {message: parseInt($(this).attr('data-key'))}, notify:true});
-      AddingDots();
+      AddingDots('#uid#');
     });
 
     /* Fan speed */
@@ -185,7 +185,7 @@
     // Send selected fan speed to Melcloud
     $(".eqLogic[data-eqLogic_uid=#uid#] .FanSelection label").click(function(){
       jeedom.cmd.execute({id: '#FanSpeed_Cmd#', value: {message: parseInt($(this).attr('data-key'))}, notify:true});
-      AddingDots();
+      AddingDots('#uid#');
     });
 
     /* Horizontal Vane */
@@ -210,7 +210,7 @@
     
     $(".eqLogic[data-eqLogic_uid=#uid#] .HoziSelection label").click(function(){
       jeedom.cmd.execute({id: '#HoriVane_Cmd#', value: {message: parseInt($(this).attr('data-key'))}, notify:true});
-      AddingDots();
+      AddingDots('#uid#');
     });
 
     /* Vertical Vane */
@@ -235,7 +235,7 @@
     
     $(".eqLogic[data-eqLogic_uid=#uid#] .VertiSelection label").click(function(){
       jeedom.cmd.execute({id: '#VertiVane_Cmd#', value: {message: parseInt($(this).attr('data-key'))}, notify:true});
-      AddingDots();
+      AddingDots('#uid#');
     });
 
     /* Temperature */

--- a/docs/fr_FR/changelog_beta.md
+++ b/docs/fr_FR/changelog_beta.md
@@ -7,5 +7,9 @@
     - Deux cron, 1 peu fréquent pour la mise à jour des paramètres des équipements. 1 autre pour la mise à jour des états des équipements.
  - Ajouter la possibilité de choisir quel élément du widget afficher ou non (parmi `Scénario`, `Mode`, `Vitesse de ventillation`, `Ailettes horizontales`, `Ailettes verticales`, `Température`, `Météo`)
 
+# 13/10/2022
+ - Modification gestion cron. Passage à un cron journalier pour les informations de la PAC et le cron toutes les 5 minutes est remplacé par une récupération des informations des splits.
+ - Correction d'un bug d'affichage qui faisait afficher des points de rafraichissement sur tous les équipements, au lieu de seulement celui sur lequel l'action a été lancé.
+
 # 03/10/2022
 Création du plugin en version bêta.

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -20,6 +20,7 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
 
 /** Fonction exécutée automatiquement après l'installation du plugin */
   function mitsubishimelcloud_install() {
+    // Create the 2 neededs cron
     $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeMELCloud');
     if (!is_object($cron)) {
       $cron = new cron();
@@ -27,24 +28,38 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
       $cron->setFunction('SynchronizeMELCloud');
       $cron->setEnable(1);
       $cron->setDeamon(0);
-      $cron->setSchedule('*/5 * * * *');
+      $cron->setSchedule(checkAndFixCron(mitsubishimelcloud::DEFAULT_SYNC_CRON));
+      $cron->setTimeout('60');
+      $cron->save();
+    }
+    $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeSplit');
+    if (!is_object($cron)) {
+      $cron = new cron();
+      $cron->setClass('mitsubishimelcloud');
+      $cron->setFunction('SynchronizeSplit');
+      $cron->setEnable(1);
+      $cron->setDeamon(0);
+      $cron->setSchedule(checkAndFixCron(mitsubishimelcloud::DEFAULT_SPLIT_CRON));
       $cron->setTimeout('60');
       $cron->save();
     }
 
-    //Add some configuration, language as French, and latest MELCloud version (when plugin was created)
+    // Add some configuration, language as French, and latest MELCloud version (when plugin was created)
     $Language = config::byKey('Language', 'mitsubishimelcloud');
     if (empty($Language)) {
       config::save('Language', '7', 'mitsubishimelcloud');
     }
     $AppVersion = config::byKey('AppVersion', 'mitsubishimelcloud');
     if (empty($AppVersion)) {
-      config::save('AppVersion', '1.24.3.0', 'mitsubishimelcloud');
+      config::save('AppVersion', '1.25.0.1', 'mitsubishimelcloud');
     }
   }
 
 /** Fonction exécutée automatiquement après la mise à jour du plugin */
   function mitsubishimelcloud_update() {
+    log::add('mitsubishimelcloud', 'info', '<------------ Start installation update ------------');
+
+    log::add('mitsubishimelcloud', 'debug', 'Update complete synchronisation to MELCloud server');
     $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeMELCloud');
     if (!is_object($cron)) {
       $cron = new cron();
@@ -52,16 +67,45 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
       $cron->setFunction('SynchronizeMELCloud');
       $cron->setEnable(1);
       $cron->setDeamon(0);
-      $cron->setSchedule('*/5 * * * *');
+      $cron->setSchedule(checkAndFixCron(mitsubishimelcloud::DEFAULT_SYNC_CRON));
+      $cron->setTimeout('60');
+      $cron->save();
+    } else {
+      $cron->setSchedule(checkAndFixCron(mitsubishimelcloud::DEFAULT_SYNC_CRON));
+      $cron->save();
+    }
+    
+    log::add('mitsubishimelcloud', 'debug', 'Update synchronisation of splits to MELCloud server');
+    $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeSplit');
+    if (!is_object($cron)) {
+      $cron = new cron();
+      $cron->setClass('mitsubishimelcloud');
+      $cron->setFunction('SynchronizeSplit');
+      $cron->setEnable(1);
+      $cron->setDeamon(0);
+      $cron->setSchedule(checkAndFixCron(mitsubishimelcloud::DEFAULT_SPLIT_CRON));
       $cron->setTimeout('60');
       $cron->save();
     }
+
     $cron->stop();
+
+    //Update MELCloud app version
+    log::add('mitsubishimelcloud', 'debug', 'Update MELCloud app version');
+    $AppVersion = config::byKey('AppVersion', 'mitsubishimelcloud');
+    config::save('AppVersion', '1.25.0.1', 'mitsubishimelcloud');
+
+    log::add('mitsubishimelcloud', 'info', '------------ Complete installation update ------------>');
   }
 
 /** Fonction exécutée automatiquement après la suppression du plugin */
   function mitsubishimelcloud_remove() {
     $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeMELCloud');
+    if (is_object($cron)) {
+      $cron->remove();
+    }
+
+    $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeSplit');
     if (is_object($cron)) {
       $cron->remove();
     }

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -59,7 +59,7 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
   function mitsubishimelcloud_update() {
     log::add('mitsubishimelcloud', 'info', '<------------ Start installation update ------------');
 
-    log::add('mitsubishimelcloud', 'debug', 'Update complete synchronisation to MELCloud server');
+    log::add('mitsubishimelcloud', 'debug', 'Update complete synchronisation cron parameters to MELCloud server');
     $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeMELCloud');
     if (!is_object($cron)) {
       $cron = new cron();
@@ -75,7 +75,7 @@ require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
       $cron->save();
     }
     
-    log::add('mitsubishimelcloud', 'debug', 'Update synchronisation of splits to MELCloud server');
+    log::add('mitsubishimelcloud', 'debug', 'Update synchronisation of splits cron parameters to MELCloud server');
     $cron = cron::byClassAndFunction('mitsubishimelcloud', 'SynchronizeSplit');
     if (!is_object($cron)) {
       $cron = new cron();


### PR DESCRIPTION
Was considering only 1 cron for the complete heat pump every 5 minutes.
Now the complete heat pump cron is launched once per day (during the night), and a second cron dedicated to each split is launched every 5 minutes.

Dots was displayed on all split refresh buttons.
Now the dots appear on only correct split.